### PR TITLE
_BSD_SOURCE is deprecated since glibc 2.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ WLD_PACKAGE_LIBS   ?= $(call pkgconfig,$(WLD_PACKAGES),libs,LIBS)
 CLEAN_FILES += $(WLD_STATIC_OBJECTS) $(WLD_SHARED_OBJECTS)
 
 FINAL_CFLAGS = $(CFLAGS) -fvisibility=hidden -std=c99
-FINAL_CPPFLAGS = $(CPPFLAGS) -D_XOPEN_SOURCE=700 -D_BSD_SOURCE
+FINAL_CPPFLAGS = $(CPPFLAGS) -D_XOPEN_SOURCE=700
 
 # Warning/error flags
 FINAL_CFLAGS += -Werror=implicit-function-declaration -Werror=implicit-int \

--- a/drm.c
+++ b/drm.c
@@ -24,6 +24,8 @@
 #include "drm.h"
 #include "drm-private.h"
 
+#include <sys/sysmacros.h>
+
 const static struct drm_driver * drivers[] = {
 #if WITH_DRM_INTEL
     &intel_drm_driver,


### PR DESCRIPTION
_BSD_SOURCE is deprecated since glibc 2.20
and will output a lot of warnings when compiling with
a new version of glibc.

Following the suggestions on
https://sourceware.org/glibc/wiki/Release/2.20#Packaging_Changes

The first step is to try to remove the define _BSD_SOURCE
(in case it's not really needed)
If that's not possible you can define both _BSD_SOURCE and
_DEFAULT_SOURCE, so you are both backward and
forward compatible.
