### PR TITLE
Enable warnings

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,7 +1,7 @@
 # wld: config.mk
 
 CC                  = gcc
-CFLAGS              = -pipe
+CFLAGS              = -O2 -Wall -Wextra -pipe
 
 ENABLE_DEBUG        = 1
 ENABLE_STATIC       = 1

--- a/config.mk
+++ b/config.mk
@@ -1,7 +1,7 @@
 # wld: config.mk
 
 CC                  = gcc
-CFLAGS              = -O2 -Wall -Wextra -Wno-unused-parametr -Wno-unused-const-variable -pipe
+CFLAGS              = -O1 -Wall -Wno-unused-parametr -Wno-unused-const-variable -pipe
 
 ENABLE_DEBUG        = 1
 ENABLE_STATIC       = 1

--- a/config.mk
+++ b/config.mk
@@ -1,7 +1,7 @@
 # wld: config.mk
 
 CC                  = gcc
-CFLAGS              = -O2 -Wall -Wextra -pipe
+CFLAGS              = -O2 -Wall -Wextra -Wno-unused-parametr -Wno-unused-const-variable -pipe
 
 ENABLE_DEBUG        = 1
 ENABLE_STATIC       = 1


### PR DESCRIPTION
Warnings with basic optimization should be enabled and fixed.
There is a lot of warnings.
intel.c: In function 'renderer_draw_text':
intel.c:292:16: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (length == -1)
                ^~
Package wayland-client was not found in the pkg-config search path.
Perhaps you should add the directory containing `wayland-client.pc'
to the PKG_CONFIG_PATH environment variable
No package 'wayland-client' found
  CC    intel/batch.o
Package wayland-client was not found in the pkg-config search path.
Perhaps you should add the directory containing `wayland-client.pc'
to the PKG_CONFIG_PATH environment variable
No package 'wayland-client' found
  CC    pixman.o
pixman.c: In function 'context_create_renderer':
pixman.c:66:68: warning: unused parameter 'context' [-Wunused-parameter]
 struct wld_renderer * context_create_renderer(struct wld_context * context)
                                                                    ^~~~~~~
pixman.c: In function 'context_create_buffer':
pixman.c:105:60: warning: unused parameter 'context' [-Wunused-parameter]
 struct buffer * context_create_buffer(struct wld_context * context,
                                                            ^~~~~~~
pixman.c:107:65: warning: unused parameter 'flags' [-Wunused-parameter]
                                       uint32_t format, uint32_t flags)
                                                                 ^~~~~
pixman.c: In function 'context_import_buffer':
pixman.c:129:60: warning: unused parameter 'context' [-Wunused-parameter]
 struct buffer * context_import_buffer(struct wld_context * context,
                                                            ^~~~~~~
pixman.c: In function 'context_destroy':
pixman.c:161:43: warning: unused parameter 'context' [-Wunused-parameter]
 void context_destroy(struct wld_context * context)
                                           ^~~~~~~
pixman.c: In function 'renderer_capabilities':
pixman.c:165:54: warning: unused parameter 'renderer' [-Wunused-parameter]
 uint32_t renderer_capabilities(struct wld_renderer * renderer,
                                                      ^~~~~~~~
pixman.c:166:48: warning: unused parameter 'buffer' [-Wunused-parameter]
                                struct buffer * buffer)
                                                ^~~~~~
pixman.c: In function 'destroy_image':
pixman.c:173:44: warning: unused parameter 'image' [-Wunused-parameter]
 static void destroy_image(pixman_image_t * image, void * data)
                                            ^~~~~
pixman.c: In function 'map_export':
pixman.c:180:69: warning: unused parameter 'buffer' [-Wunused-parameter]
 bool map_export(struct wld_exporter * exporter, struct wld_buffer * buffer,
                                                                     ^~~~~~
pixman.c: In function 'renderer_draw_text':
pixman.c:339:34: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     pixman_glyph_t glyphs[length == -1 ? (length = strlen(text)) : length];
                                  ^~
pixman.c: In function 'renderer_flush':
pixman.c:421:43: warning: unused parameter 'renderer' [-Wunused-parameter]
 void renderer_flush(struct wld_renderer * renderer)
                                           ^~~~~~~~
pixman.c: In function 'buffer_map':
pixman.c:433:33: warning: unused parameter 'buffer' [-Wunused-parameter]
 bool buffer_map(struct buffer * buffer)
                                 ^~~~~~
pixman.c: In function 'buffer_unmap':
pixman.c:438:35: warning: unused parameter 'buffer' [-Wunused-parameter]
 bool buffer_unmap(struct buffer * buffer)
                                   ^~~~~~
Package wayland-client was not found in the pkg-config search path.
Perhaps you should add the directory containing `wayland-client.pc'
to the PKG_CONFIG_PATH environment variable
No package 'wayland-client' found
  CC    wayland.o
wayland.c:29:28: fatal error: wayland-client.h: No such file or directory
 #include <wayland-client.h>
                            ^
