### PR TITLE
Add the library directory to RPATH, too.

### DIFF
--- a/wld.pc.in
+++ b/wld.pc.in
@@ -6,7 +6,7 @@ Name: wld
 Description: A primitive drawing library library targeted at Wayland
 Version: @VERSION@
 Cflags: -I${includedir}
-Libs: -L${libdir} -lwld
+Libs: -L${libdir} -Wl,-R${libdir} -lwld
 
 Requires: @WLD_REQUIRES@
 Requires.private: @WLD_REQUIRES_PRIVATE@


### PR DESCRIPTION
This helps find the library if it's installed in a non-standard place.