### PR TITLE
Added OpenBSD support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ WLD_LIB_LINK    := libwld.so
 WLD_LIB_SONAME  := $(WLD_LIB_LINK).$(VERSION_MAJOR)
 WLD_LIB         := $(WLD_LIB_LINK).$(VERSION)
 
+WLD_LDFLAGS     := -Wl,-soname,$(WLD_LIB_SONAME)
+
 TARGETS         := wld.pc
 CLEAN_FILES     :=
 
@@ -100,6 +102,13 @@ ifeq ($(shell uname),NetBSD)
     FINAL_CPPFLAGS += -D_NETBSD_SOURCE
 endif
 
+ifeq ($(shell uname),OpenBSD)
+    # Needed for 'major' macros
+    FINAL_CPPFLAGS += -D_BSD_SOURCE
+else
+    WLD_LDFLAGS += -WL,-no-undefined
+endif
+
 ifeq ($(ENABLE_DEBUG),1)
     FINAL_CPPFLAGS += -DENABLE_DEBUG=1
     FINAL_CFLAGS += -g
@@ -155,7 +164,7 @@ libwld.a: $(WLD_STATIC_OBJECTS)
 	$(call quiet,AR) cr $@ $^
 
 $(WLD_LIB): $(WLD_SHARED_OBJECTS)
-	$(link) $(WLD_PACKAGE_LIBS) -shared -Wl,-soname,$(WLD_LIB_SONAME),-no-undefined
+	$(link) $(WLD_PACKAGE_LIBS) -shared $(WLD_LDFLAGS)
 
 $(WLD_LIB_SONAME) $(WLD_LIB_LINK): $(WLD_LIB)
 	$(call quiet,SYM,ln -sf) $< $@

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ ifeq ($(shell uname),OpenBSD)
     # Needed for 'major' macros
     FINAL_CPPFLAGS += -D_BSD_SOURCE
 else
-    WLD_LDFLAGS += -WL,-no-undefined
+    WLD_LDFLAGS += -Wl,-no-undefined
 endif
 
 ifeq ($(ENABLE_DEBUG),1)

--- a/wayland-shm.c
+++ b/wayland-shm.c
@@ -177,7 +177,11 @@ context_create_buffer(struct wld_context *base,
 
 	unlink(name);
 
+#ifdef __OpenBSD__
+	if (ftruncate(fd, size) != 0)
+#else
 	if (posix_fallocate(fd, 0, size) != 0 && ftruncate(fd, size) != 0)
+#endif
 		goto error2;
 
 	if (!(pool = wl_shm_create_pool(context->wl, fd, size)))


### PR DESCRIPTION
### `Makefile`
- As the CPP `XOPEN_SOURCE=700` is used, OpenBSD won't define the `major` macro defined in `<sys/types.h>`, unless we define the `_BSD_SOURCE`.
- OpenBSD does not have DT_NEEDED entries for libc. Thus `-Wl,-no-undefined` check would fail. I've added `WLD_LDFLAGS` variable, and appended the `-Wl,-no-undefined` linker flag if `$ uname != OpenBSD`.

### `wayland-shm.c`
OpenBSD does not implement the `posix_fallocate` call. Only `ftruncate` is used.